### PR TITLE
Return default license details when license key is not set

### DIFF
--- a/updater/FluentLicensing.php
+++ b/updater/FluentLicensing.php
@@ -119,7 +119,7 @@ class FluentLicensing
             ];
         }
 
-        if (!$remoteFetch) {
+        if (!$remoteFetch || empty($currentLicense['license_key'])) {
             return $currentLicense; // Return the current license status without fetching from the API.
         }
 


### PR DESCRIPTION
### What

Skip the remote `check_license` API call in `FluentLicensing::getStatus()` when no license key is stored, and return the default unregistered license details instead.

```php
if (!$remoteFetch || empty($currentLicense['license_key'])) {
    return $currentLicense;
}
```

### Why

When a site has no license key saved, `getStatus(true)` still went ahead and hit the remote API. That path caused three problems:

1. **Wasted API request.** The `check_license` call is sent with an empty `license_key` and is guaranteed to fail. There is nothing to check.

2. **Spurious database write.** After the failed remote call, the status update branch is entered because the default status `'unregistered'` is a non-empty string. That triggers `update_option($this->settingsKey, ...)`, persisting a license record for a site that never had a license.

3. **PHP warning.** The default license array does not include an `activation_hash` key, but the remote request reads `$currentLicense['activation_hash']`, producing an undefined array key warning on every such call.

Returning early when there is no key to validate avoids all three.

### Impact

No user-facing behaviour change. The license settings page only issues the remote status request when a license is already registered, so this guard only affects programmatic `getStatus(true)` calls on unlicensed sites.
